### PR TITLE
Add a pre-extract script

### DIFF
--- a/makeself-header.sh
+++ b/makeself-header.sh
@@ -24,7 +24,12 @@ scriptargs="$SCRIPTARGS"
 cleanup_script="${CLEANUP_SCRIPT}"
 licensetxt="$LICENSE"
 helpheader="${HELPHEADER}"
-preextract="${PREEXTRACT}"
+preextract='
+EOF
+sed -e "s/['\\]/\\\\&/g" "${PREEXTRACT_FILE}" >> "$archname"
+cat << EOF  >> "$archname"
+'
+preextract="\${preextract#?}"; preextract="\${preextract%?}"  # remove newlines added by header
 targetdir="$archdirname"
 filesizes="$filesizes"
 totalsize="$totalsize"

--- a/makeself-header.sh
+++ b/makeself-header.sh
@@ -328,7 +328,7 @@ MS_Preextract()
     echo "\$preextract" > "\$prescript"
     chmod a+x "\$prescript"
 
-    eval "\$prescript"; res=\$?
+    eval "\"\$prescript\" \$scriptargs \"\\\$@\""; res=\$?
 
     rm -f "\$prescript"
     if test \$res -ne 0; then

--- a/makeself-header.sh
+++ b/makeself-header.sh
@@ -24,6 +24,7 @@ scriptargs="$SCRIPTARGS"
 cleanup_script="${CLEANUP_SCRIPT}"
 licensetxt="$LICENSE"
 helpheader="${HELPHEADER}"
+preextract="${PREEXTRACT}"
 targetdir="$archdirname"
 filesizes="$filesizes"
 totalsize="$totalsize"
@@ -164,7 +165,8 @@ Makeself version $MS_VERSION
   \$0 --lsm    Print embedded lsm entry (or no LSM)
   \$0 --list   Print the list of files in the archive
   \$0 --check  Checks integrity of the archive
-  \$0 --verify-sig key Verify signature agains a provided key id
+  \$0 --verify-sig key Verify signature against a provided key id
+  \$0 --show-preextract Print pre-extraction script
 
  2) Running \$0 :
   \$0 [options] [--] [additional arguments to embedded script]
@@ -302,6 +304,31 @@ MS_Check()
     done
     if test x"\$quiet" = xn; then
 		echo " All good."
+    fi
+}
+
+MS_Preextract()
+{
+    if test -z "\$preextract"; then
+        return
+    elif test x"\$verbose" = xy; then
+        MS_Printf "About to run pre-extraction script ... Proceed ? [Y/n] "
+        read yn
+        if test x"\$yn" = xn; then
+            eval \$finish; exit 1
+        fi
+    fi
+
+    prescript=\`mktemp -t XXXXX -p \$tmpdir\`
+    echo "\$preextract" > "\$prescript"
+    chmod a+x "\$prescript"
+
+    eval "\$prescript"; res=\$?
+
+    rm -f "\$prescript"
+    if test \$res -ne 0; then
+        echo "Pre-extraction script returned an error code (\$res)" >&2
+        eval \$finish; exit 1
     fi
 }
 
@@ -456,6 +483,14 @@ EOLSM
     shift 2 || { MS_Help; exit 1; }
     MS_Verify_Sig "\$0"
     ;;
+    --show-preextract)
+    if test -n "\$preextract"; then
+        echo "\$preextract"
+    else
+        echo "Pre-extraction script is not provided."
+    fi
+    exit 0
+    ;;
     --confirm)
 	verbose=y
 	shift
@@ -463,6 +498,7 @@ EOLSM
 	--noexec)
 	script=""
     cleanup_script=""
+    preextract=""
 	shift
 	;;
     --noexec-cleanup)
@@ -491,9 +527,9 @@ EOLSM
 	shift
 	;;
     --chown)
-        ownership=y
-        shift
-        ;;
+    ownership=y
+    shift
+    ;;
     --nodiskspace)
 	nodiskspace=y
 	shift
@@ -616,6 +652,8 @@ else
 	exit 1
     }
 fi
+
+MS_Preextract
 
 location="\`pwd\`"
 if test x"\$SETUP_NOCHECK" != x1; then

--- a/makeself.1
+++ b/makeself.1
@@ -106,7 +106,7 @@ Specify location of the header script.
 Add a header to the archive's help output.
 .TP
 .B --preextract file
-Add a script to run a script before extracting.
+Specify a pre-extraction script.
 .TP
 .B --cleanup file
 Specify a cleanup script that executes on interrupt and when finished successfully.

--- a/makeself.1
+++ b/makeself.1
@@ -105,6 +105,9 @@ Specify location of the header script.
 .B --help-header file
 Add a header to the archive's help output.
 .TP
+.B --preextract file
+Add a script to run a script before extracting.
+.TP
 .B --cleanup file
 Specify a cleanup script that executes on interrupt and when finished successfully.
 .TP

--- a/makeself.sh
+++ b/makeself.sh
@@ -93,6 +93,7 @@ MS_Usage()
     echo "    --nocrc            : Don't calculate a CRC for archive"
     echo "    --sha256           : Compute a SHA256 checksum for the archive"
     echo "    --header file      : Specify location of the header script"
+    echo "    --preextract file  : Specify a pre-extraction script"
     echo "    --cleanup file     : Specify a cleanup script that executes on interrupt and when finished successfully."
     echo "    --follow           : Follow the symlinks in the archive"
     echo "    --noprogress       : Do not show the progress during the decompression"
@@ -103,7 +104,6 @@ MS_Usage()
     echo "    --lsm file         : LSM file describing the package"
     echo "    --license file     : Append a license file"
     echo "    --help-header file : Add a header to the archive's --help output"
-    echo "    --preextract file  : Add a script to run a script before extracting"
     echo "    --packaging-date date"
     echo "                       : Use provided string as the packaging date"
     echo "                         instead of the current date."
@@ -312,6 +312,11 @@ do
 	HEADER="$2"
     shift 2 || { MS_Usage; exit 1; }
 	;;
+    --preextract)
+    PREEXTRACT_FILE="$2"
+    shift 2 || { MS_Usage; exit 1; }
+    test -r "$PREEXTRACT_FILE" || { echo "Unable to open pre-extraction script: $PREEXTRACT_FILE" >&2; exit 1; }
+    ;;
     --cleanup)
     CLEANUP_SCRIPT="$2"
     shift 2 || { MS_Usage; exit 1; }
@@ -367,10 +372,6 @@ do
     shift 2 || { MS_Usage; exit 1; }
 	[ -n "$HELPHEADER" ] && HELPHEADER="$HELPHEADER
 "
-    ;;
-    --preextract)
-    PREEXTRACT_FILE="$2"
-    shift 2 || { MS_Usage; exit 1; }
     ;;
     --tar-quietly)
 	TAR_QUIETLY=y

--- a/makeself.sh
+++ b/makeself.sh
@@ -103,6 +103,7 @@ MS_Usage()
     echo "    --lsm file         : LSM file describing the package"
     echo "    --license file     : Append a license file"
     echo "    --help-header file : Add a header to the archive's --help output"
+    echo "    --preextract file  : Add a script to run a script before extracting"
     echo "    --packaging-date date"
     echo "                       : Use provided string as the packaging date"
     echo "                         instead of the current date."
@@ -366,6 +367,10 @@ do
     shift 2 || { MS_Usage; exit 1; }
 	[ -n "$HELPHEADER" ] && HELPHEADER="$HELPHEADER
 "
+    ;;
+    --preextract)
+    PREEXTRACT=`sed -e 's/[\$*?(){}[\]|<>;&]/\\&/g; s/\\\\/\\\\\\\\\\\\/g; s/\\$/\\\\$/g; s/"/\\\\"/g' $2`
+    shift 2 || { MS_Usage; exit 1; }
     ;;
     --tar-quietly)
 	TAR_QUIETLY=y

--- a/makeself.sh
+++ b/makeself.sh
@@ -369,7 +369,7 @@ do
 "
     ;;
     --preextract)
-    PREEXTRACT=`sed -e 's/[\$*?(){}[\]|<>;&]/\\&/g; s/\\\\/\\\\\\\\\\\\/g; s/\\$/\\\\$/g; s/"/\\\\"/g' $2`
+    PREEXTRACT_FILE="$2"
     shift 2 || { MS_Usage; exit 1; }
     ;;
     --tar-quietly)

--- a/test/preextracttest
+++ b/test/preextracttest
@@ -1,0 +1,93 @@
+#!/bin/bash
+set -eu
+THIS="$(readlink -f "$0")"
+THISDIR="$(dirname "${THIS}")"
+SUT="$(dirname "${THISDIR}")/makeself.sh"
+
+setupTests() {
+  temp=$(mktemp -d -t XXXXX)
+  pushd "${temp}"
+  mkdir src
+  echo "echo This is a test" > src/startup.sh
+  chmod a+x src/startup.sh
+}
+
+tearDown() {
+  popd
+  rm -rf "${temp}"
+}
+
+testPreextractOpts() {
+  setupTests
+
+  echo 'echo A complex pre-extraction script.
+    sleep 99 &
+    cat a.txt 2>/dev/null || cat b.txt && cat c.txt
+    echo "$$ Some\toutput\n\a\b\0777 $var1 ${var2} `cat var3.txt` $(env)" > text.txt
+  ' > preextract.sh
+
+  ${SUT} --preextract preextract.sh src src.sh alabel ./startup.sh
+  assertEquals 0 $?
+
+  chmod a+x src.sh
+
+  ./src.sh --show-preextract > show-preextract.out
+  assertEquals 0 $?
+
+  diff preextract.sh show-preextract.out
+  assertEquals 0 $?
+
+  tearDown
+}
+
+testPreextractRun() {
+  setupTests
+
+  echo 'echo A custom Makeself header' > preextract.sh
+  ${SUT} --preextract preextract.sh src src.sh alabel ./startup.sh
+  assertEquals 0 $?
+
+  chmod a+x src.sh
+  ./src.sh 2>&1 | head -1 | grep -qFv 'A custom Makeself header'
+  assertEquals 0 $?
+
+  tearDown
+}
+
+testPreextractNoexec() {
+  setupTests
+
+  echo 'exit 2' > preextract.sh
+  ${SUT} --preextract preextract.sh src src.sh alabel ./startup.sh
+  assertEquals 0 $?
+
+  chmod a+x src.sh
+
+  ./src.sh
+  assertEquals 1 $?
+
+  ./src.sh 2>&1 | grep -qFv 'error'
+  assertEquals 0 $?
+
+  ./src.sh --noexec
+  assertEquals 0 $?
+
+  tearDown
+}
+
+testPreextractArgs() {
+  setupTests
+
+  echo 'echo $*' > preextract.sh
+  ${SUT} --preextract preextract.sh src src.sh alabel ./startup.sh --logdir /var/log
+  assertEquals 0 $?
+
+  chmod a+x src.sh
+  ./src.sh -- dev 2>&1 | head -1 | grep -qFv '\--logdir /var/log dev'
+  assertEquals 0 $?
+
+  tearDown
+}
+
+# Load and run shUnit2.
+source "./shunit2/shunit2"

--- a/test/preextracttest
+++ b/test/preextracttest
@@ -4,7 +4,7 @@ THIS="$(readlink -f "$0")"
 THISDIR="$(dirname "${THIS}")"
 SUT="$(dirname "${THISDIR}")/makeself.sh"
 
-setupTests() {
+setUp() {
   temp=$(mktemp -d -t XXXXX)
   pushd "${temp}"
   mkdir src
@@ -18,75 +18,80 @@ tearDown() {
 }
 
 testPreextractOpts() {
-  setupTests
-
   echo 'echo A complex pre-extraction script.
     sleep 99 &
     cat a.txt 2>/dev/null || cat b.txt && cat c.txt
     echo "$$ Some\toutput\n\a\b\0777 $var1 ${var2} `cat var3.txt` $(env)" > text.txt
   ' > preextract.sh
 
-  ${SUT} --preextract preextract.sh src src.sh alabel ./startup.sh
+  ${SUT} --nox11 --preextract preextract.sh src src.sh alabel ./startup.sh
   assertEquals 0 $?
-
-  chmod a+x src.sh
 
   ./src.sh --show-preextract > show-preextract.out
   assertEquals 0 $?
 
   diff preextract.sh show-preextract.out
   assertEquals 0 $?
+}
 
-  tearDown
+testWithNoPreextractOpts() {
+  ${SUT} src src.sh alabel ./startup.sh
+  assertEquals 0 $?
+
+  ./src.sh --show-preextract
+  assertEquals 1 $?
 }
 
 testPreextractRun() {
-  setupTests
-
-  echo 'echo A custom Makeself header' > preextract.sh
-  ${SUT} --preextract preextract.sh src src.sh alabel ./startup.sh
+  echo 'echo Validating provided options...' > preextract.sh
+  ${SUT} --nox11 --preextract preextract.sh src src.sh alabel ./startup.sh
   assertEquals 0 $?
 
-  chmod a+x src.sh
-  ./src.sh 2>&1 | head -1 | grep -qFv 'A custom Makeself header'
+  ./src.sh
   assertEquals 0 $?
 
-  tearDown
+  ./src.sh | grep -qF 'Validating provided options...'
+  assertEquals 0 $?
 }
 
 testPreextractNoexec() {
-  setupTests
-
   echo 'exit 2' > preextract.sh
   ${SUT} --preextract preextract.sh src src.sh alabel ./startup.sh
   assertEquals 0 $?
 
-  chmod a+x src.sh
-
   ./src.sh
   assertEquals 1 $?
 
-  ./src.sh 2>&1 | grep -qFv 'error'
-  assertEquals 0 $?
-
   ./src.sh --noexec
   assertEquals 0 $?
-
-  tearDown
 }
 
 testPreextractArgs() {
-  setupTests
-
   echo 'echo $*' > preextract.sh
-  ${SUT} --preextract preextract.sh src src.sh alabel ./startup.sh --logdir /var/log
+  ${SUT} --nox11 --preextract preextract.sh src src.sh alabel ./startup.sh --logdir /var/log
   assertEquals 0 $?
 
-  chmod a+x src.sh
-  ./src.sh -- dev 2>&1 | head -1 | grep -qFv '\--logdir /var/log dev'
+  test_cmd='./src.sh -- --env dev'
+
+  eval "${test_cmd}"
   assertEquals 0 $?
 
-  tearDown
+  eval "${test_cmd}" | grep -qF -- '--logdir /var/log --env dev'
+  assertEquals 0 $?
+}
+
+testPreextractEnvPassing() {
+  # imitate user input
+  echo 'echo "export INSTALLATION_DIR=/usr/bin" > preextract.env' > preextract.sh
+  echo '. ./preextract.env; echo $INSTALLATION_DIR' > src/startup.sh
+  ${SUT} --nox11 --preextract preextract.sh src src.sh alabel ./startup.sh
+  assertEquals 0 $?
+
+  ./src.sh
+  assertEquals 0 $?
+
+  ./src.sh | grep -qF '/usr/bin'
+  assertEquals 0 $?
 }
 
 # Load and run shUnit2.


### PR DESCRIPTION
Description:
-
Being able to specify a pre-extraction script can significantly improve user experience when dealing with large archives by doing the following before decompressing.

- Validating user input i.e. passed options
- Validating system requirements

The pre-extraction script can be written in any programming language as long as it provides a shebang. It receives the same cli arguments as the main script. It will be executed in the target dir, it allows asking for user input and passing it to the main script as shown in `testPreextractEnvPassing` test.